### PR TITLE
Show the calendar urls only on the calendar page

### DIFF
--- a/app/views/sidebar/_calendars.html.erb
+++ b/app/views/sidebar/_calendars.html.erb
@@ -1,19 +1,21 @@
 <%# redmics - redmine ics export plugin, Copyright (c) 2010-2011 Frank Schwarz, frank.schwarz@buschmais.com %>
+<%# Only show Calendars in Calendar view (peter@pflaeging.net) %>
 <%
   user = User.current
 %>
-<% if user.allowed_to?(:view_calendar, project, :global => true) %>
+
+<% if user.allowed_to?(:view_calendar, project, :global => true) and current_menu_item().to_s == "calendar" %>
   <h3><%= l(:label_icalendar_header) %></h3>
   <% unless user.anonymous? %>
   <%= link_to l(:label_issues_mine), { :controller => 'i_calendar', :assignment => :my, :action => 'index', :project_id => project, :key => user.rss_key, :format => 'ics' }, :title => l(:toolip_icalendar_link) %>
-  (<%= link_to l(:label_issues_open_only), { :controller => 'i_calendar', :assignment => :my, :status => 'open', :action => 'index', :project_id => project, :key => user.rss_key, :format => 'ics' }, :title => l(:toolip_icalendar_link) %>)
+  -- (<%= link_to l(:label_issues_open_only), { :controller => 'i_calendar', :assignment => :my, :status => 'open', :action => 'index', :project_id => project, :key => user.rss_key, :format => 'ics' }, :title => l(:toolip_icalendar_link) %>)
   <br/>
   <% end %>
   <%= link_to l(:label_issues_assigned), { :controller => 'i_calendar', :assignment => :assigned, :action => 'index', :project_id => project, :key => user.rss_key, :format => 'ics' }, :title => l(:toolip_icalendar_link) %>
-  (<%= link_to l(:label_issues_open_only), { :controller => 'i_calendar', :assignment => :assigned, :status => 'open', :action => 'index', :project_id => project, :key => user.rss_key, :format => 'ics' }, :title => l(:toolip_icalendar_link) %>)
+  -- (<%= link_to l(:label_issues_open_only), { :controller => 'i_calendar', :assignment => :assigned, :status => 'open', :action => 'index', :project_id => project, :key => user.rss_key, :format => 'ics' }, :title => l(:toolip_icalendar_link) %>)
   <br/>
   <%= link_to l(:label_issues_all), { :controller => 'i_calendar', :assignment => :all, :action => 'index', :project_id => project, :key => user.rss_key, :format => 'ics' }, :title => l(:toolip_icalendar_link) %>
-  (<%= link_to l(:label_issues_open_only), { :controller => 'i_calendar', :assignment => :all, :status => 'open', :action => 'index', :project_id => project, :key => user.rss_key, :format => 'ics' }, :title => l(:toolip_icalendar_link) %>)
+  -- (<%= link_to l(:label_issues_open_only), { :controller => 'i_calendar', :assignment => :all, :status => 'open', :action => 'index', :project_id => project, :key => user.rss_key, :format => 'ics' }, :title => l(:toolip_icalendar_link) %>)
   <% if @query && @query.id %>
   <br/>
   <%= link_to @query.name, { :controller => 'i_calendar', :query_id => @query.id, :action => 'index', :project_id => project, :key => user.rss_key, :format => 'ics' }, :title => l(:toolip_icalendar_link) %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,6 +1,6 @@
 # German strings go here
 de:
-  label_icalendar_header: ICalendar
+  label_icalendar_header: Kalender Abo
   label_issues_mine: Meine Tickets
   label_issues_assigned: Zugewiesene Tickets
   label_issues_all: Alle Tickets

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,6 @@
 # English strings go here
 en:
-  label_icalendar_header: ICalendar
+  label_icalendar_header: Calendar abo
   label_issues_mine: My issues
   label_issues_assigned: Assigned issues
   label_issues_all: All issues


### PR DESCRIPTION
For better usability and an uncluttered view of the sidebar:

- patch to show the ICalendar view only on the sidebar of the calendar page
- changed the title and appearance a little bit

Greetings

:peter