### PR TITLE
Rails 5 support

### DIFF
--- a/app/controllers/i_calendar_controller.rb
+++ b/app/controllers/i_calendar_controller.rb
@@ -16,18 +16,24 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 require 'icalendar'
+require_relative '../../lib/redmics/export'
+require_relative '../../lib/redmics/query_conditions'
 
 class ICalendarController < ApplicationController
   unloadable
   
   accept_rss_auth :index
-  before_filter :find_user,
+
+  before_method = self.respond_to?(:before_filter) ? :before_filter : :before_action
+  send(before_method,
+                :find_user,
                 :find_optional_project,
                 :find_optional_query,
                 :decode_rendering_settings_from_url,
                 :authorize_access, 
                 :check_and_complete_params,
                 :load_settings
+      )
   
   def index
     e = Redmics::Export.new(self)

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -16,10 +16,23 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 module ApplicationControllerFindCurrentUserICS
+
+  module PrependMethods
+    def find_current_user
+      find_current_user_with_ics
+      super
+    end
+  end
+
   def self.included(base)
     base.class_eval {
       include InstanceMethods
-      alias_method_chain :find_current_user, :ics
+      if self.respond_to?(:alias_method_chain)
+        alias_method_chain :find_current_user, :ics
+      else
+        alias_method :find_current_user_without_ics, :find_current_user
+        prepend PrependMethods
+      end
     }
   end
 
@@ -36,10 +49,22 @@ module ApplicationControllerFindCurrentUserICS
 end
 
 module SettingsControllerPluginDefaults
+
+  module PrependMethods
+    def plugin
+      plugin_with_defaults
+    end
+  end
+
   def self.included(base)
     base.class_eval {
       include InstanceMethods
-      alias_method_chain :plugin, :defaults
+      if self.respond_to?(:alias_method_chain)
+        alias_method_chain :plugin, :defaults
+      else
+        alias_method :plugin_without_defaults, :plugin
+        prepend PrependMethods
+      end
     }
   end
 


### PR DESCRIPTION
Tested on 

```
Environment:
  Redmine version                4.0.0.devel
  Ruby version                   2.4.5-p335 (2018-10-18) [amd64-freebsd11]
  Rails version                  5.2.2
  Environment                    production
```

Kept backwards compatibility to former Redmine versions.